### PR TITLE
Reusable button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,4 +1,13 @@
 @import "tailwindcss";
+
+@theme {
+  --color-primary: #3B413C;
+  --color-secondary: #9DB5B2;
+  --color-accent: #C4AEF1;
+  --color-background: #EFEFEF;
+  --color-content-background: #FFFFFF;
+}
+
 #root {
   max-width: 1280px;
   margin: 0 auto;
@@ -12,9 +21,11 @@
   will-change: filter;
   transition: filter 300ms;
 }
+
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);
 }
+
 .logo.react:hover {
   filter: drop-shadow(0 0 2em #61dafbaa);
 }
@@ -23,6 +34,7 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,9 @@ import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
-  // const [countFive, setCountFive] = useState(0)
+  const handleReportIssue = () => {
+    console.log('Star Command, we have an issue!')
+  }
 
   return (
     <>
@@ -25,15 +27,22 @@ function App() {
       </Card>
       <div className="card">
         <MainButton onClick={() => setCount((count) => count + 1)}
-          variant='accent'
+          variant='secondary'
           size='lg'
           fullWidth={false}
         >
           <p>count is {count}</p>
         </MainButton>
-        {/* <button onClick={() => setCountFive((countFive) => countFive + 5)}>
-          count is {countFive}
-        </button> */}
+        <MainButton
+          className='my-2'
+          variant="accent"
+          size='md'
+          fullWidth
+          icon={<p className="text-accent">⚠️</p>} // icon={<FaExclamationTriangle className="text-accent" />}
+          onClick={handleReportIssue}
+        >
+          Report An Issue
+        </MainButton>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import Card from './components/Card';
+import MainButton from './components/MainButton';
 import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
+  // const [countFive, setCountFive] = useState(0)
 
   return (
     <>
@@ -19,12 +21,19 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <Card title="Fancy Card" icon="🧑‍💻">
-        Hello, Friends!
+        <p>Hello, Friends!</p>
       </Card>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <MainButton onClick={() => setCount((count) => count + 1)}
+          variant='accent'
+          size='lg'
+          fullWidth={false}
+        >
+          <p>count is {count}</p>
+        </MainButton>
+        {/* <button onClick={() => setCountFive((countFive) => countFive + 5)}>
+          count is {countFive}
+        </button> */}
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/frontend/src/components/MainButton.tsx
+++ b/frontend/src/components/MainButton.tsx
@@ -1,0 +1,48 @@
+import { ButtonHTMLAttributes, ReactNode } from "react";
+
+interface MainButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    children: ReactNode;
+    variant?: 'primary' | 'secondary' | 'accent' | 'background' | 'content-background' | 'icon';
+    fullWidth?: boolean;
+    icon?: ReactNode;
+    iconPosition?: 'left' | 'right';
+    size?: 'sm' | 'md' | 'lg';
+    className?: string;
+    noHoverTransform?: boolean;
+}
+
+const MainButton = ({
+    children,
+    variant = 'primary',
+    fullWidth = false,
+    icon,
+    iconPosition = 'left',
+    size = 'md',
+    className = "",
+    noHoverTransform = false,
+    ...props
+}: MainButtonProps) => {
+    return (
+        <button
+            className={`rounded transition-all duration-200 flex items-center justify-center mx-auto
+            ${variant === 'primary' ? 'bg-primary hover:bg-primary/80 text-white' : ''}
+            ${variant === 'secondary' ? 'bg-secondary hover:bg-secondary/80 text-primary' : ''}
+            ${variant === 'accent' ? 'bg-[#C4AEF1] hover:bg-[#C4AEF1]/80 text-white' : ''}
+            ${variant === 'background' ? 'bg-background hover:bg-background/80 text-white ' : ''}
+            ${variant === 'content-background' ? 'bg-content-background hover:bg-content-background/80 text-white ' : ''}
+            ${variant === 'icon' ? 'bg-accent hover:bg-accent/80 text-white rounded-full p-2' : ''}
+            ${fullWidth ? 'w-full' : ''}
+            ${noHoverTransform ? 'hover:transform-none' : ''}
+            ${variant != icon ? (size === 'sm' ? 'text-sm py-1 px-3' : size === 'md' ? 'py-2 px-4' : size === 'lg' ? 'text-lg py-3 px-6' : '') : ''}
+            ${className}
+            `}
+            {...props}
+        >
+            {icon && iconPosition === 'left' && <span className={children ? 'mr-2' : ''}>{icon}</span>}
+            {children}
+            {icon && iconPosition === 'right' && <span className={children ? 'ml-2' : ''}>{icon}</span>}
+        </button>
+    );
+};
+
+export default MainButton;

--- a/frontend/src/components/MainButton.tsx
+++ b/frontend/src/components/MainButton.tsx
@@ -24,10 +24,10 @@ const MainButton = ({
 }: MainButtonProps) => {
     return (
         <button
-            className={`rounded transition-all duration-200 flex items-center justify-center mx-auto
+            className={`rounded transition-all duration-200 flex items-center justify-center mx-auto cursor-pointer
             ${variant === 'primary' ? 'bg-primary hover:bg-primary/80 text-white' : ''}
             ${variant === 'secondary' ? 'bg-secondary hover:bg-secondary/80 text-primary' : ''}
-            ${variant === 'accent' ? 'bg-[#C4AEF1] hover:bg-[#C4AEF1]/80 text-white' : ''}
+            ${variant === 'accent' ? 'bg-accent hover:bg-accent/80 text-primary' : ''}
             ${variant === 'background' ? 'bg-background hover:bg-background/80 text-white ' : ''}
             ${variant === 'content-background' ? 'bg-content-background hover:bg-content-background/80 text-white ' : ''}
             ${variant === 'icon' ? 'bg-accent hover:bg-accent/80 text-white rounded-full p-2' : ''}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,7 @@ a {
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }
@@ -35,7 +36,7 @@ h1 {
   line-height: 1.1;
 }
 
-button {
+/* button {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
@@ -45,10 +46,12 @@ button {
   background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
-}
+} */
+
 button:hover {
   border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -59,9 +62,11 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+
   a:hover {
     color: #747bff;
   }
+
   button {
     background-color: #f9f9f9;
   }


### PR DESCRIPTION
This PR introduces a reusable button component that can be used across the application. I commented out the conflicting boilerplate button CSS to avoid styling issues.

Changes:
- Created a reusable <MainButton /> component.
- Applied Tailwind CSS for colors and styling according to Figma.
- Commented out conflicting boilerplate button CSS.

Example:
```
<MainButton
          className='my-2'
          variant="accent"
          size='md'
          fullWidth
          icon={<p className="text-accent">⚠️</p>} // icon={<FaExclamationTriangle className="text-accent" />}
          onClick={handleReportIssue}
        >
          Report An Issue
        </MainButton>
```