### PR TITLE
Fix: remove opacity from dashboard hero card

### DIFF
--- a/frontend/src/pages/TenantDashboard.tsx
+++ b/frontend/src/pages/TenantDashboard.tsx
@@ -18,6 +18,7 @@ const TenantDashboard = () => {
     })();
   }, []);
 
+
   return (
     <div className="min-h-screen bg-background">
       {/* TODO: Create header component */}

--- a/frontend/src/tenantDashboard/components/HeroCard.tsx
+++ b/frontend/src/tenantDashboard/components/HeroCard.tsx
@@ -44,7 +44,7 @@ const HeroCard = ({
             </div>
 
             {/* Notification Card */}
-            <div className="bg-secondary/90 rounded-4xl -mt-28 mx-4 overflow-hidden">
+            <div className="bg-secondary rounded-4xl -mt-28 mx-4 overflow-hidden">
                 {notifications.map((notification, index) => (
                     <div
                         key={index}


### PR DESCRIPTION
remove opacity from notifications on the dashboard hero card.
<img width="487" alt="Screen Shot 2025-03-12 at 2 56 37 AM" src="https://github.com/user-attachments/assets/3d538d87-4391-4ff3-863e-d56edefce724" />
