### PR TITLE
added route to fetch lease expiration countdown

### DIFF
--- a/apartment_portal_api/apartment_portal_api/Services/EmailValidator.cs
+++ b/apartment_portal_api/apartment_portal_api/Services/EmailValidator.cs
@@ -32,10 +32,12 @@ public static class EmailValidator
         }
         catch (RegexMatchTimeoutException e)
         {
+            Console.WriteLine(e);
             return false;
         }
         catch (ArgumentException e)
         {
+            Console.WriteLine(e);
             return false;
         }
 


### PR DESCRIPTION
Allows admin to get all user lease expiration countdown.
Allows tenant to only get their own lease expiration countdown.